### PR TITLE
Fixes #1, changed name to "QuantumOpsDemos"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# QuantumDemos
+# QuantumOpsDemos
 
 This repository contains some notebooks for
 [QuantumOps.jl](https://github.ibm.com/John-Lapeyre/QuantumOps.jl)


### PR DESCRIPTION
The name of repo in readme has been changed to "QuantumOpsDemos"